### PR TITLE
Add debug information to gas builds

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,7 +36,7 @@
         {
           "label": "gas",
           "type": "shell",
-          "command": "rawfilename=${fileDirname}/${fileBasenameNoExtension}; as ${file} -o $rawfilename.o; ld $rawfilename.o -o $rawfilename",
+          "command": "rawfilename=${fileDirname}/${fileBasenameNoExtension}; as --gstabs+ ${file} -o $rawfilename.o; ld $rawfilename.o -o $rawfilename",
           "problemMatcher": {
               "pattern": {
                 "regexp": "error"


### PR DESCRIPTION
I tried your config but my breakpoints were not getting recognized. Fixed by telling `as` to include relevant debug information.